### PR TITLE
Add tablecraft-player — play 13+ board games via CLI

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1.0",
-  "last_updated": "2026-03-10",
+  "last_updated": "2026-05-02",
   "description": "Curated registry of verified Claude Code skills. Searched as Strategy 0 before hitting GitHub API.",
   "skills": [
     {
@@ -197,6 +197,22 @@
       "stars": 346,
       "last_verified": "2026-03-10",
       "domains": ["web-development", "general"]
+    },
+    {
+      "id": "clarence-g-tablecraft-player-v1",
+      "name": "TableCraft Player",
+      "description": "Play 13+ turn-based board games (Gomoku, UNO, Poker, Blackjack, Yahtzee, Hive, Love Letter, Splendor, Connect Four, Battleship, Codenames, Liar's Bar, Undercover) on the TableCraft multiplayer platform via CLI.",
+      "source": "github",
+      "repo": "Clarence-G/tablecraft",
+      "path": "skill_data/tablecraft-player/SKILL.md",
+      "tags": ["board-games", "gaming", "multiplayer", "gomoku", "uno", "poker", "bot-player", "cli", "json", "ai-agent"],
+      "aliases": ["tablecraft-cli", "tablecraft-bot", "play-boardgame", "board-game-bot", "claude-plays-games"],
+      "verified": false,
+      "trust_score": 0,
+      "stars": 0,
+      "last_verified": "2026-05-02",
+      "domains": ["general"],
+      "note": "Gaming / AI-agent skill. Also distributed via npm `tablecraft-cli` (bundles SKILL.md); install via `npm i -g tablecraft-cli && ln -s \"$(tablecraft skill-path | jq -r .path)\" ~/.claude/skills/tablecraft-player`. Live server: https://tablecraft.aster.pub"
     }
   ],
   "domains": {
@@ -267,7 +283,7 @@
     "scientific": ["research", "science", "academic", "analysis"]
   },
   "metadata": {
-    "total_skills": 13,
+    "total_skills": 14,
     "verified_skills": 13,
     "format_version": "1.1.0",
     "notes": "All entries are real, verified skill repositories discovered through live GitHub API testing on 2026-03-10."


### PR DESCRIPTION
## Summary

Adds `tablecraft-player` skill to the curated registry.

## Skill Overview

- **Name:** TableCraft Player
- **Repo:** [Clarence-G/tablecraft](https://github.com/Clarence-G/tablecraft)
- **SKILL.md:** [`skill_data/tablecraft-player/SKILL.md`](https://github.com/Clarence-G/tablecraft/blob/main/skill_data/tablecraft-player/SKILL.md)
- **npm package:** [`tablecraft-cli@0.1.1`](https://www.npmjs.com/package/tablecraft-cli) (bundles the SKILL.md in its tarball)
- **Live service:** https://tablecraft.aster.pub
- **License:** MIT

## What it does

Teaches an AI agent (Claude Code / Codex / Cursor) the standard request→wait→act loop for turn-based multiplayer games via a single CLI tool. Every command returns `{ ok, data }` JSON on stdout, so agents parse deterministically. One skill handles every game — `tablecraft games rules <id>` returns each game's JSON action schema at runtime.

## Installation

```bash
npm i -g tablecraft-cli
ln -s "$(tablecraft skill-path | jq -r .path)" ~/.claude/skills/tablecraft-player
tablecraft login --server https://tablecraft.aster.pub --token <bot-token>
```

## Registry changes

- `skills[]` — new entry `clarence-g-tablecraft-player-v1`
- `metadata.total_skills` — 13 → 14
- `last_updated` — bumped to 2026-05-02
- Domain: `general` (no `gaming` / `ai-agents` domain yet; happy to open a separate PR to add those to `domains` + `query_synonyms` if maintainers want)

## Quality

- MIT licensed, live production service, 13+ working games
- CLI has `skill-path` subcommand so install instructions are copy-paste from `npm i` to `~/.claude/skills/` symlink
- SKILL.md has full frontmatter (version, license, author, homepage, repository, tags) per claude-skill hub conventions
- Source code is actively developed (commits within 24h of this PR)

No security concerns — skill only uses the bundled `tablecraft` CLI (no arbitrary shell execution).
